### PR TITLE
improving logging and save result on errors too

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     async_request (1.0.0)
       jwt (~> 2.1)
       rails (>= 4.2)
-      sidekiq (>= 4.2, < 6)
+      sidekiq (>= 4.0, < 6)
 
 GEM
   remote: https://rubygems.org/
@@ -88,7 +88,7 @@ GEM
       method_source (~> 0.8.1)
       slop (~> 3.4)
     rack (1.6.4)
-    rack-protection (2.0.0)
+    rack-protection (2.0.1)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -144,11 +144,11 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
-    sidekiq (5.0.5)
+    sidekiq (5.1.3)
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (>= 1.5.0)
-      redis (>= 3.3.4, < 5)
+      redis (>= 3.3.5, < 5)
     simplecov (0.11.2)
       docile (~> 1.1.0)
       json (~> 1.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     async_request (1.0.0)
       jwt (~> 2.1)
       rails (>= 4.2)
-      sidekiq (~> 4.0)
+      sidekiq (>= 4.2, < 6)
 
 GEM
   remote: https://rubygems.org/
@@ -118,7 +118,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (3.0.0)
     rake (11.1.2)
-    redis (3.3.5)
+    redis (4.0.1)
     rspec-core (3.4.4)
       rspec-support (~> 3.4.0)
     rspec-expectations (3.4.0)
@@ -144,11 +144,11 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
-    sidekiq (4.2.10)
+    sidekiq (5.0.5)
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (>= 1.5.0)
-      redis (~> 3.2, >= 3.2.1)
+      redis (>= 3.3.4, < 5)
     simplecov (0.11.2)
       docile (~> 1.1.0)
       json (~> 1.8)
@@ -183,4 +183,4 @@ DEPENDENCIES
   rubocop (~> 0.52)
 
 BUNDLED WITH
-   1.15.3
+   1.16.1

--- a/app/models/async_request/job.rb
+++ b/app/models/async_request/job.rb
@@ -39,7 +39,8 @@ module AsyncRequest
       Rails.logger.info("Processing failed for job with id=#{id}")
       Rails.logger.info(error.message)
       Rails.logger.info(error.backtrace.inspect)
-      update_attributes(status: :failed, status_code: 500, response: error.message)
+      update_attributes!(status: :failed, status_code: 500,
+                         response: { error: error.message }.to_json)
     end
 
     private

--- a/app/models/async_request/job.rb
+++ b/app/models/async_request/job.rb
@@ -18,6 +18,7 @@ module AsyncRequest
     end
 
     def successfully_processed!(response, status_code)
+      Rails.logger.info("Processing finished successfully for job with id=#{id}")
       update_attributes!(
         status: :processed,
         status_code: map_status_code(status_code),
@@ -25,12 +26,20 @@ module AsyncRequest
       )
     end
 
+    def processing!
+      Rails.logger.info("Processing job with id=#{id}")
+      super
+    end
+
     def finished?
       processed? || failed?
     end
 
-    def finished_with_errors!
-      update_attributes(status: :failed, status_code: 500)
+    def finished_with_errors!(error)
+      Rails.logger.info("Processing failed for job with id=#{id}")
+      Rails.logger.info(error.message)
+      Rails.logger.info(error.backtrace.inspect)
+      update_attributes(status: :failed, status_code: 500, response: error.message)
     end
 
     private

--- a/app/workers/async_request/job_processor.rb
+++ b/app/workers/async_request/job_processor.rb
@@ -8,8 +8,8 @@ module AsyncRequest
       begin
         status, response = job.worker.constantize.new.execute(*job.params)
         job.successfully_processed!(response, status)
-      rescue StandardError
-        job.finished_with_errors!
+      rescue StandardError => e
+        job.finished_with_errors! e
       end
     end
   end

--- a/async_request.gemspec
+++ b/async_request.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir['spec/**/*']
 
   s.add_dependency 'rails', '>= 4.2'
-  s.add_dependency 'sidekiq', '>= 4.2', '< 6'
+  s.add_dependency 'sidekiq', '>= 4.0', '< 6'
   s.add_dependency 'jwt', '~> 2.1'
 
   s.add_development_dependency 'pg'

--- a/async_request.gemspec
+++ b/async_request.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir['spec/**/*']
 
   s.add_dependency 'rails', '>= 4.2'
-  s.add_dependency 'sidekiq', '~> 4.0'
+  s.add_dependency 'sidekiq', '>= 4.2', '< 6'
   s.add_dependency 'jwt', '~> 2.1'
 
   s.add_development_dependency 'pg'


### PR DESCRIPTION
# Summary
- When an exception happens, the job returns "{ status_code: 500, response: nil }" and nothing gets logged. My suggestion is saving the error message as response and also add logs to the different job steps: processing, process succesfull and process failures.