### PR TITLE
Update sidekiq dependency up to v6

### DIFF
--- a/async_request.gemspec
+++ b/async_request.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["spec/**/*"]
 
   s.add_dependency "rails", ">= 4.2"
-  s.add_dependency "sidekiq", "~> 4.0"
+  s.add_dependency 'sidekiq', '>= 4.0', '< 6'
 
   s.add_development_dependency "pg"
   s.add_development_dependency "pry"

--- a/lib/async_request/version.rb
+++ b/lib/async_request/version.rb
@@ -1,3 +1,3 @@
 module AsyncRequest
-  VERSION = '0.0.7'.freeze
+  VERSION = '0.0.8'.freeze
 end


### PR DESCRIPTION
## Summary

- Update sidekiq dependency to work up to version 6 for the gem's version-0